### PR TITLE
[#3] Github Actions - Build Ci 추가

### DIFF
--- a/.github/kkyuni_github_actions.yml
+++ b/.github/kkyuni_github_actions.yml
@@ -1,4 +1,4 @@
-name: Kkyuni Acttions
+name: Kkyuni Actions
 on:
   pull_request:
     branches:

--- a/.github/kkyuni_github_actions.yml
+++ b/.github/kkyuni_github_actions.yml
@@ -1,0 +1,27 @@
+name: Kkyuni Acttions
+on:
+  pull_request:
+    branches: 
+      - develop
+    types: [opened, synchronize, reopened, edited, ready_for_review, review_requested]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: set up JDK
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: 11
+          cache: 'gradle'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Bukld with Gradle
+        run: ./gradlew build

--- a/.github/kkyuni_github_actions.yml
+++ b/.github/kkyuni_github_actions.yml
@@ -1,19 +1,20 @@
 name: Kkyuni Acttions
 on:
   pull_request:
-    branches: 
+    branches:
       - develop
     types: [opened, synchronize, reopened, edited, ready_for_review, review_requested]
 
 jobs:
-  build:
+  ci:
+    name: Build
     runs-on: ubuntu-latest
     
     steps:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: set up JDK
+      - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
           distribution: 'zulu'
@@ -23,5 +24,8 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - name: Bukld with Gradle
-        run: ./gradlew build
+      - name: Ktlint
+        run: ./gradlew spotlessCheck
+
+      - name: Build with Gradle
+        run: ./gradlew build --stacktrace

--- a/.github/kkyuni_github_actions.yml
+++ b/.github/kkyuni_github_actions.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
     branches:
       - develop
-    types: [opened, synchronize, reopened, edited, ready_for_review, review_requested]
+    types: [opened, synchronize]
 
 jobs:
   ci:

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,6 +5,8 @@ plugins {
     id 'kotlin-kapt'
 }
 
+apply from: "$rootDir/spotless.gradle"
+
 android {
     compileSdk 31
 

--- a/app/src/androidTest/java/com/mashup/kkyuni/ExampleInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/mashup/kkyuni/ExampleInstrumentedTest.kt
@@ -1,12 +1,25 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.mashup.kkyuni
 
-import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.ext.junit.runners.AndroidJUnit4
-
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
-
-import org.junit.Assert.*
 
 /**
  * Instrumented test, which will execute on an Android device.

--- a/app/src/androidTest/java/com/mashup/kkyuni/ExampleInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/mashup/kkyuni/ExampleInstrumentedTest.kt
@@ -1,18 +1,3 @@
-/*
- * Copyright 2021 The Android Open Source Project
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.mashup.kkyuni
 
 import androidx.test.ext.junit.runners.AndroidJUnit4

--- a/app/src/main/java/com/mashup/kkyuni/KKyuniApplication.kt
+++ b/app/src/main/java/com/mashup/kkyuni/KKyuniApplication.kt
@@ -4,5 +4,4 @@ import android.app.Application
 import dagger.hilt.android.HiltAndroidApp
 
 @HiltAndroidApp
-class KKyuniApplication: Application() {
-}
+class KKyuniApplication : Application()

--- a/app/src/main/java/com/mashup/kkyuni/MainActivity.kt
+++ b/app/src/main/java/com/mashup/kkyuni/MainActivity.kt
@@ -1,18 +1,3 @@
-/*
- * Copyright 2021 The Android Open Source Project
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.mashup.kkyuni
 
 import android.os.Bundle

--- a/app/src/main/java/com/mashup/kkyuni/MainActivity.kt
+++ b/app/src/main/java/com/mashup/kkyuni/MainActivity.kt
@@ -1,7 +1,22 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.mashup.kkyuni
 
-import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
 
 class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/test/java/com/mashup/kkyuni/ExampleUnitTest.kt
+++ b/app/src/test/java/com/mashup/kkyuni/ExampleUnitTest.kt
@@ -1,18 +1,3 @@
-/*
- * Copyright 2021 The Android Open Source Project
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package com.mashup.kkyuni
 
 import org.junit.Assert.assertEquals

--- a/app/src/test/java/com/mashup/kkyuni/ExampleUnitTest.kt
+++ b/app/src/test/java/com/mashup/kkyuni/ExampleUnitTest.kt
@@ -1,8 +1,22 @@
+/*
+ * Copyright 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.mashup.kkyuni
 
+import org.junit.Assert.assertEquals
 import org.junit.Test
-
-import org.junit.Assert.*
 
 /**
  * Example local unit test, which will execute on the development machine (host).

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.0.2'
+        classpath "com.diffplug.spotless:spotless-plugin-gradle:5.15.0"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         classpath "com.google.dagger:hilt-android-gradle-plugin:$hiltVersion"
 

--- a/spotless.gradle
+++ b/spotless.gradle
@@ -1,0 +1,11 @@
+apply plugin: 'com.diffplug.spotless'
+spotless {
+    kotlin {
+        target '**/*.kt'
+        targetExclude("$buildDir/**/*.kt")
+        targetExclude('bin/**/*.kt')
+
+        ktlint("0.42.1")
+        licenseHeaderFile rootProject.file('spotless/copyright.kt')
+    }
+}

--- a/spotless.gradle
+++ b/spotless.gradle
@@ -6,6 +6,8 @@ spotless {
         targetExclude('bin/**/*.kt')
 
         ktlint("0.42.1")
-        licenseHeaderFile rootProject.file('spotless/copyright.kt')
+
+        // Todo: 추후 추가 - https://github.com/mash-up-kr/KKyuni_Android/pull/5#pullrequestreview-755993281
+        // licenseHeaderFile rootProject.file('spotless/copyright.kt')
     }
 }

--- a/spotless/copyright.kt
+++ b/spotless/copyright.kt
@@ -1,0 +1,15 @@
+/*
+ * Copyright $YEAR The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */


### PR DESCRIPTION
## Issue
- #3

## Overview (Required)
- Github Action 을 사용해 Build Ci를 적용했습니다.
  - `./gradlew spotlessCheck`를 실행해 KTLint 검사 
  - `./gradlew build` 를 실행해 Build 성공 시 통과
  
실패 시|성공 시
:--:|:--:
<img width="929" alt="스크린샷 2021-09-15 오후 3 07 09" src="https://user-images.githubusercontent.com/57310034/133557201-021c2fec-121c-4ccf-a812-f7b56af3f3c8.png">|<img width="919" alt="스크린샷 2021-09-15 오후 3 09 36" src="https://user-images.githubusercontent.com/57310034/133557217-4f0e265f-5e20-4de8-b40b-11077dfdce2b.png">

## 주의 사항
- import 시 wild card 사용이 허용되지 않습니다.
  - `import org.junit.Assert.*`(X) -> `import org.junit.Assert.assertEquals`(O)
  - IDE 설정에서 wild card 를 사용하지 않도록 설정해두면 편리합니다.
    - [IntelliJ 공식 문서 - Disable wildcard imports](https://www.jetbrains.com/help/idea/creating-and-optimizing-imports.html#disable-imports)
    ![image](https://user-images.githubusercontent.com/57310034/133558127-cbf369db-07e1-4c67-b49c-c86da513cd95.png)
- Push 전에 미리 KTLint 를 돌려보면 편리합니다.
  - `./gradlew spotlessCheck` : KTLint 검사
  - `./gradlew spotlessApply` : KTLint 가 제안하는 변경을 적용

## CI?
- 지속적인 통합(Continuous Integration)
- 개발자를 위한 자동화 프로세스
- 새로운 변경 사항에 빌드 및 테스트 등의 작업을 주기적으로 수행함으로써 여러 개발자들이 하나의 어플리케이션을 개발할 때 발생할 수 있는 문제들(충돌 및 에러 등)을 빠르게 발견하고 해결하기 위함
- 각각의 변경점들을 __지속적으로__ 빌드 및 테스트하면서 기존 어플리케이션에 완전히 __통합__ 시키는 과정이라고 할 수 있다.
- 같은 맥락으로 배포 과정을 자동화 한다면 CD (Continuous Delivery)
- 도구
  - [Jenkins](https://www.jenkins.io/)
  - [Buddy](https://buddy.works/)
  - [Github Actions](https://docs.github.com/en/actions)

## Github Action ?
- Github 에서 제공하는 커스텀 가능한 Workflow 툴
  - repository의 소프트웨어의 워크 플로우를 자동화하거나 커스터마이징하고 이를 실행할 수 있게 해준다.
  - CI/CD를 포함해 어떠한 Job이라도 수행할 수 있는 action들을 코드로 작성하여 공유하고, 재사용할 수 있다.
  - 타 CI/CD 도구에 비해 가격이 저렴(사이드 프로젝트는 무료 수준으로 사용 가능)하고 마켓 플레이스를 통해 이미 만들어진 Job들을 재사용할 수 있다는 장점이 있어 채택

## KTLint ?
- Kotlin 컨벤션에 대한 Bikeshedding 을 방지하기 위한 lint 도구
  - Bikeshedding
    - Parkinson 의 사소함의 법칙(Law of Triviality)의 은유적인 표현으로, 중요하고 복잡한 문제에 대해서는 적은 시간을 들이지만 비교적 사소하고 이해하기 쉬운 문제에 대해서는 많은 시간을 들이는 현상을 말한다.
- 가장 중요한 개발 과정보다 눈에 바로 보이는 Kotllin 컨벤션을 신경쓰느라 시간을 허비하지 않도록 하기 위해서 자동으로 컨벤션을 검사하고 교정해줄 수 있는 도구이다.
- 여러 개발자들이 작성하는 코드의 컨벤션에 대한 일관성을 제공할 수도 있음
- [기본 룰](https://github.com/pinterest/ktlint#standard-rules)
- __여기서는 Spotless 를 통해 KTLint 를 적용했습니다.__

### Spotless ?
- Code formatter 플러그인
- 컨벤션 룰을 적용해서 실행시킬 수 있다
  - 여기서는 컨벤션 룰을 KTLint로 적용
- 멀티 모듈을 고려하고 있기 때문에 spotless.gradle 파일을 루트 경로에 따로 분리했습니다.
  - 각 모듈에 대한 `build.gradle` 에서 `apply from`을 통해 해당 플러그인을 적용합니다.
  - reference : [[안드로이드] 멀티 모듈 공통 gradle 그리고 ktlint 적용을 해보자](https://keelim.tistory.com/entry/%EC%95%88%EB%93%9C%EB%A1%9C%EC%9D%B4%EB%93%9C-%EB%A9%80%ED%8B%B0-%EB%AA%A8%EB%93%88-%EA%B3%B5%ED%86%B5-gradle-%EA%B7%B8%EB%A6%AC%EA%B3%A0-ktlint-%EC%A0%81%EC%9A%A9%EC%9D%84-%ED%95%B4%EB%B3%B4%EC%9E%90)

## 의문점
- OpenJDK Distribution
  - Github actions 에서 제공해주는 [JDK 셋업 도구](https://github.com/actions/setup-java)는 다음과 같은 distribution 을 제공합니다.
    | Keyword | Distribution | Official site | License
    |-|-|-|-|
    | `temurin` | Eclipse Temurin | [Link](https://adoptium.net/) | [Link](https://adoptium.net/about.html)
    | `zulu` | Zulu OpenJDK | [Link](https://www.azul.com/downloads/zulu-community/?package=jdk) | [Link](https://www.azul.com/products/zulu-and-zulu-enterprise/zulu-terms-of-use/) |
    | `adopt` or `adopt-hotspot` | Adopt OpenJDK Hotspot | [Link](https://adoptopenjdk.net/) | [Link](https://adoptopenjdk.net/about.html) |
    | `adopt-openj9` | Adopt OpenJDK OpenJ9 | [Link](https://adoptopenjdk.net/) | [Link](https://adoptopenjdk.net/about.html)
  - 안드로이드에서 사용하는 JDK 는 뭘까요 ? 확인할 수 있는 방법을 잘 모르겠습니다.
  - 우선은 다들 zulu 를 사용하길래 동일하게 적용했습니다. 

## Reference :  
- [CI/CD(지속적 통합/지속적 제공): 개념, 방법, 장점, 구현 과정](https://www.redhat.com/ko/topics/devops/what-is-ci-cd)
- [15 Best Continuous Integration Tools In 2021 (Compared)
](https://www.softwaretestinghelp.com/tools/24-best-continuous-integration-tool/)
- [사소함의 법칙(Law of Triviality)](https://brunch.co.kr/@hifism/30)
- [KTLint](https://ktlint.github.io/)
- [Spotless](https://github.com/diffplug/spotless)
- [compose-sample : build.gradle](https://github.com/android/compose-samples/blob/main/JetNews/build.gradle)
