### PR TITLE
[#10] 싱글 액티비티 세팅

### DIFF
--- a/app/src/main/java/com/mashup/kkyuni/MainActivity.kt
+++ b/app/src/main/java/com/mashup/kkyuni/MainActivity.kt
@@ -2,7 +2,9 @@ package com.mashup.kkyuni
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/com/mashup/kkyuni/StartFragment.kt
+++ b/app/src/main/java/com/mashup/kkyuni/StartFragment.kt
@@ -1,0 +1,14 @@
+package com.mashup.kkyuni
+
+import androidx.fragment.app.Fragment
+
+/**
+ * 실제로는 사용하지 않는 Fragment.
+ * 화면 플로우에 맞게 순서대로 개발되지 않기 때문에
+ * 해당 Fragment 뒤에 각자 개발하는 Fragment 를 붙여 테스트 합니다.
+ * Commit 할 땐 해당 Fragment 를 제외합니다.
+ * 만약 직전 Fragment 가 완성되어 merge 된 상태라면 플로우에 맞게 연결 후 push 합니다.
+ *
+ * Todo: 개발이 완료되거나 더 이상 불필요하다고 판단되는 시점에서 해당 Fragment 를 완전히 제거합니다.
+ */
+class StartFragment: Fragment()

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -6,13 +6,16 @@
     android:layout_height="match_parent"
     tools:context=".MainActivity">
 
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Hello World!"
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/fragmentcontainerview_main"
+        android:name="androidx.navigation.fragment.NavHostFragment"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:defaultNavHost="true"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:navGraph="@navigation/navigation_main" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/navigation/navigation_main.xml
+++ b/app/src/main/res/navigation/navigation_main.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/nav_main.xml"
+    app:startDestination="@id/startFragment">
+
+    <fragment
+        android:id="@+id/startFragment"
+        android:name="com.mashup.kkyuni.StartFragment"
+        android:label="StartFragment" />
+
+</navigation>


### PR DESCRIPTION
## Issue
- close #10

## Overview (Required)
- 싱글 액티비티를 적용하기로 협의가 되었습니다.
- 본격적으로 개발을 시작하기 전, 관련 세팅을 먼저 해두어야 불필요한 중복 작업과 conflict 를 피할 수 있다고 판단했습니다.
- 기본 시작 Fragment 가 필요하기 때문에 (`app:startDestination` attribute) `StartFragment` 라는 임시 Fragment 를 생성했습니다.
  - 주석에도 설명을 달아놓았지만, 해당 Fragment 는 실제로는 사용하지 않으며 화면 Flow 의 순서와 개발 순서가 일치하지 않기 때문에 해당 Fragment 뒤에 붙이거나 대체하여 테스트를 하면 좋을 것 같습니다.
  - 다만, Commit 및 Push 시에는 `StartFragment` 를 제외합니다. (실제 상용 코드가 아니며, 다른 브랜치와 conflict 가능성이 있음)
