### PR TITLE
[#11] BindingFragment 추가

### DIFF
--- a/app/src/main/java/com/mashup/kkyuni/base/BindingFragment.kt
+++ b/app/src/main/java/com/mashup/kkyuni/base/BindingFragment.kt
@@ -1,0 +1,34 @@
+package com.mashup.kkyuni.base
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.annotation.LayoutRes
+import androidx.databinding.DataBindingUtil
+import androidx.databinding.ViewDataBinding
+import androidx.fragment.app.Fragment
+
+class BindingFragment<B : ViewDataBinding>(@LayoutRes private val contentLayoutId: Int) : Fragment() {
+
+    private var _binding: B? = null
+    protected val binding: B
+        get() {
+            if (_binding == null) {
+                throw NullPointerException("binding is null. Please refer it in ViewLifeCycle (onCreateView ~ onDestroyView)")
+            } else {
+                return _binding!!
+            }
+        }
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        _binding = DataBindingUtil.inflate(inflater, contentLayoutId, container, false)
+        _binding?.lifecycleOwner = viewLifecycleOwner
+        return binding.root
+    }
+
+    override fun onDestroyView() {
+        _binding = null
+        super.onDestroyView()
+    }
+}


### PR DESCRIPTION
## Issue
- #11

## Overview (Required)
- DataBinding 을 사용하는 Fragment에 사용할 수 있는 Base 클래스인 `BindingFragment` 를 추가했습니다.
- `onCreateView()` 에서 Layout 을 inflate 하고, 맴버 필드(`_binding`)에 할당합니다.
  - 해당 필드는 `onDestroyView()` 에서 null로 초기화되어 메모리 누수를 방지합니다.
- `BindingFragment` 를 사용하는 Fragment 는 protected 필드인 `binding` 을 통해 바인딩 인스턴스를 참조합니다.
  - 해당 필드는 `_binding` 필드를 참조하며, 해당 값이 null 일 경우에는 예외를 발생시킵니다.
  - null 이 아닐 경우에는 `!!` 를 사용하기 때문에, Fragment에서는 추가적인 null check 를 필요로 하지 않습니다.

## References
- https://developer.android.com/topic/libraries/view-binding#fragments
