### PR TITLE
[#20] 스플래시 화면 구성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,6 +108,7 @@ obj/
 /out/
 
 # User-specific configurations
+.idea/*
 .idea/caches/
 .idea/libraries/
 .idea/shelf/

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -90,4 +90,8 @@ dependencies {
     // Coil
     def coilVersion = "1.3.2"
     implementation "io.coil-kt:coil:$coilVersion"
+
+    // Splash Screen
+    def splashScreenVersion = "1.0.0-alpha02"
+    implementation "androidx.core:core-splashscreen:$splashScreenVersion"
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,7 +9,7 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/Theme.KkyuniKkyuni">
+        android:theme="@style/Theme.App.Starting">
         <activity
             android:name=".MainActivity"
             android:exported="true">

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,7 +9,7 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/Theme.App.Starting">
+        android:theme="@style/Theme.App">
         <activity
             android:name=".MainActivity"
             android:exported="true">

--- a/app/src/main/java/com/mashup/kkyuni/MainActivity.kt
+++ b/app/src/main/java/com/mashup/kkyuni/MainActivity.kt
@@ -2,12 +2,14 @@ package com.mashup.kkyuni
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        installSplashScreen()
         setContentView(R.layout.activity_main)
     }
 }

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -13,7 +13,7 @@
         <item name="android:statusBarColor" tools:targetApi="l">?attr/colorPrimaryVariant</item>
         <!-- Customize your theme here. -->
     </style>
-    <style name="Theme.App.Starting" parent="Theme.SplashScreen">
+    <style name="Theme.App" parent="Theme.SplashScreen">
         <item name="windowSplashScreenBackground">@color/black</item>
         <item name="windowSplashScreenAnimatedIcon">@drawable/ic_launcher_foreground</item>
         <item name="windowSplashScreenAnimationDuration">200</item>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -12,8 +12,6 @@
         <!-- Status bar color. -->
         <item name="android:statusBarColor" tools:targetApi="l">?attr/colorPrimaryVariant</item>
         <!-- Customize your theme here. -->
-        <item name="windowSplashScreenBackground">@color/black</item>-->
-
     </style>
     <style name="Theme.App.Starting" parent="Theme.SplashScreen">
         <item name="windowSplashScreenBackground">@color/black</item>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -12,5 +12,13 @@
         <!-- Status bar color. -->
         <item name="android:statusBarColor" tools:targetApi="l">?attr/colorPrimaryVariant</item>
         <!-- Customize your theme here. -->
+        <item name="windowSplashScreenBackground">@color/black</item>-->
+
+    </style>
+    <style name="Theme.App.Starting" parent="Theme.SplashScreen">
+        <item name="windowSplashScreenBackground">@color/black</item>
+        <item name="windowSplashScreenAnimatedIcon">@drawable/ic_launcher_foreground</item>
+        <item name="windowSplashScreenAnimationDuration">200</item>
+        <item name="postSplashScreenTheme">@style/Theme.AppCompat</item>
     </style>
 </resources>


### PR DESCRIPTION
## Issue
스플래시 화면 구성 #20 

## Overview (Required)
스플래시 화면 구성했습니다.
이미지는 임시로 `ic_launcher_foreground` 를 사용했습니다.

## Screenshot
<img width=240 src="https://user-images.githubusercontent.com/37477660/135614373-f016bc86-d435-4b7d-9ba9-5b6ccd611049.png"/>

## References
[기존 스플래시 화면 Android 12로 마이그레이션](https://developer.android.com/about/versions/12/splash-screen-migration)
[installSplashScreen()을 추가하지 않아 생기는 오류 해결 참고](https://proandroiddev.com/implementing-core-splashscreen-api-e62f0e690f74)

