### PR TITLE
일기 확정 시 타입 큰 따옴표 제거, 버튼 스타일 적용

### DIFF
--- a/feature/calendar/presentation/src/main/res/layout/fragment_calendar.xml
+++ b/feature/calendar/presentation/src/main/res/layout/fragment_calendar.xml
@@ -155,14 +155,15 @@
         <View
             android:layout_width="0dp"
             android:layout_height="0dp"
-            app:onThrottleClick="@{() -> viewModel.onClickWriting()}"
-            app:layout_constraintTop_toTopOf="@id/logo"
             app:layout_constraintBottom_toBottomOf="@id/textview_preview"
+            app:layout_constraintEnd_toEndOf="@id/textview_preview"
             app:layout_constraintStart_toStartOf="@id/textview_preview"
-            app:layout_constraintEnd_toEndOf="@id/textview_preview"/>
+            app:layout_constraintTop_toTopOf="@id/logo"
+            app:onThrottleClick="@{() -> viewModel.onClickWriting()}" />
 
         <com.mashup.kkyuni.widget.KkyuniBottomButton
             android:id="@+id/message"
+            style="@style/KkyuniBottomButtonStyle"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginStart="20dp"
@@ -172,10 +173,10 @@
             android:text="@string/message"
             android:textColor="@color/white"
             android:textSize="18sp"
-            app:onThrottleClick="@{() -> viewModel.onClickWriting()}"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent" />
+            app:layout_constraintStart_toStartOf="parent"
+            app:onThrottleClick="@{() -> viewModel.onClickWriting()}" />
 
         <FrameLayout
             android:id="@+id/preview_background"

--- a/feature/login/presentation/src/main/res/layout/fragment_login.xml
+++ b/feature/login/presentation/src/main/res/layout/fragment_login.xml
@@ -26,6 +26,7 @@
 
         <com.mashup.kkyuni.widget.KkyuniBottomButton
             android:id="@+id/kkyunibottombutton_login"
+            style="@style/KkyuniBottomButtonStyle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="@dimen/common_padding"

--- a/feature/music/presentation/src/main/res/layout/fragment_music.xml
+++ b/feature/music/presentation/src/main/res/layout/fragment_music.xml
@@ -60,8 +60,8 @@
             android:id="@+id/recycler"
             android:layout_width="match_parent"
             android:layout_height="0dp"
-            android:padding="10dp"
             android:layout_marginBottom="90dp"
+            android:padding="10dp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
@@ -72,11 +72,12 @@
             android:layout_height="160dp"
             android:background="@drawable/background_dim"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent" />
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent" />
 
         <com.mashup.kkyuni.widget.KkyuniBottomButton
             android:id="@+id/kkyunibottombutton_music"
+            style="@style/KkyuniBottomButtonStyle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="@dimen/common_padding"
@@ -85,18 +86,18 @@
             android:elevation="20dp"
             android:text="@string/finish_choosing"
             android:textAppearance="@style/Music.FinishButton"
-            app:onThrottleClick="@{() -> viewModel.onVideoClicked()}"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent" />
+            app:layout_constraintStart_toStartOf="parent"
+            app:onThrottleClick="@{() -> viewModel.onVideoClicked()}" />
 
         <ProgressBar
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            app:visible="@{viewModel.isShowProgress()}"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"/>
+            app:visible="@{viewModel.isShowProgress()}" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/feature/playlist/presentation/src/main/res/layout/dialog_choice_date.xml
+++ b/feature/playlist/presentation/src/main/res/layout/dialog_choice_date.xml
@@ -4,6 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
+
         <variable
             name="viewModel"
             type="com.mashup.kkyuni.feature.playlist.presentation.widget.ChoiceDateViewModel" />
@@ -12,66 +13,67 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="388dp"
-        android:paddingHorizontal="@dimen/common_padding"
-        android:background="@drawable/background_choice_date">
+        android:background="@drawable/background_choice_date"
+        android:paddingHorizontal="@dimen/common_padding">
 
         <ImageView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:src="@drawable/ic_close"
             android:layout_marginTop="@dimen/common_padding"
+            android:src="@drawable/ic_close"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="parent"/>
+            app:layout_constraintTop_toTopOf="parent" />
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/recycler_view_date"
             android:layout_width="0dp"
             android:layout_height="225dp"
-            android:layout_marginBottom="36dp"
             android:layout_marginTop="35dp"
+            android:layout_marginBottom="36dp"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+            app:layout_constraintBottom_toTopOf="@id/bottombutton_chioce_date"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintWidth_min="128dp"
             app:scrollToPosition="@{viewModel.scrollToPosition}"
-            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-            app:updateChoiceDates="@{viewModel.choiceDates}"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintBottom_toTopOf="@id/bottombutton_chioce_date" />
+            app:updateChoiceDates="@{viewModel.choiceDates}" />
 
         <View
             android:layout_width="0dp"
             android:layout_height="1dp"
-            android:background="@color/white_alpha80"
             android:layout_marginBottom="45dp"
-            app:layout_constraintWidth_max="128dp"
-            app:layout_constraintStart_toStartOf="@id/recycler_view_date"
+            android:background="@color/white_alpha80"
+            app:layout_constraintBottom_toBottomOf="@id/recycler_view_date"
             app:layout_constraintEnd_toEndOf="@id/recycler_view_date"
+            app:layout_constraintStart_toStartOf="@id/recycler_view_date"
             app:layout_constraintTop_toTopOf="@id/recycler_view_date"
-            app:layout_constraintBottom_toBottomOf="@id/recycler_view_date"/>
+            app:layout_constraintWidth_max="128dp" />
 
         <View
             android:layout_width="0dp"
             android:layout_height="1dp"
-            android:background="@color/white_alpha80"
             android:layout_marginTop="45dp"
-            app:layout_constraintWidth_max="128dp"
-            app:layout_constraintStart_toStartOf="@id/recycler_view_date"
-            app:layout_constraintEnd_toEndOf="@id/recycler_view_date"
+            android:background="@color/white_alpha80"
             app:layout_constraintBottom_toBottomOf="@id/recycler_view_date"
-            app:layout_constraintTop_toTopOf="@id/recycler_view_date"/>
+            app:layout_constraintEnd_toEndOf="@id/recycler_view_date"
+            app:layout_constraintStart_toStartOf="@id/recycler_view_date"
+            app:layout_constraintTop_toTopOf="@id/recycler_view_date"
+            app:layout_constraintWidth_max="128dp" />
 
         <com.mashup.kkyuni.widget.KkyuniBottomButton
             android:id="@+id/bottombutton_chioce_date"
+            style="@style/KkyuniBottomButtonStyle"
             android:layout_width="0dp"
             android:layout_height="56dp"
-            android:text="@string/choice_date_complete"
-            android:background="@color/purple_700"
-            android:textAppearance="@style/KkyuniBottomButtonStyle"
             android:layout_marginBottom="24dp"
-            app:onThrottleClick="@{() -> viewModel.onClickedComplete()}"
+            android:background="@color/purple_700"
+            android:text="@string/choice_date_complete"
+            android:textAppearance="@style/KkyuniBottomButtonStyle"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent" />
+            app:layout_constraintStart_toStartOf="parent"
+            app:onThrottleClick="@{() -> viewModel.onClickedComplete()}" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/feature/writing/presentation/src/main/java/com/mashup/kkyuni/feature/writing/presentation/preview/WritingPreviewFragment.kt
+++ b/feature/writing/presentation/src/main/java/com/mashup/kkyuni/feature/writing/presentation/preview/WritingPreviewFragment.kt
@@ -42,7 +42,7 @@ class WritingPreviewFragment: BindingFragment<FragmentPreviewBinding>(R.layout.f
                 settings.javaScriptEnabled = true
                 lifecycleScope.launch {
                     loadUrl("https://compassionate-wing-0abef6.netlify.app/preview")
-                    delay(5000)
+                    delay(4000)
                     evaluateJavascript("setDiary(${writingViewModel.getCurrentWriting().toJson()})") {
                         progressBar.isVisible = false
                     }
@@ -52,7 +52,7 @@ class WritingPreviewFragment: BindingFragment<FragmentPreviewBinding>(R.layout.f
             buttonConfirm.setOnClickListener {
                 webviewPreview.evaluateJavascript("selectType()") { type ->
                     writingViewModel.run {
-                        updateDiaryType(type)
+                        updateDiaryType(type.replace(Regex("\""), ""))
                         getCurrentWriting().run {
                             writingPreviewViewModel.requestUpload(this)
                         }

--- a/feature/writing/presentation/src/main/java/com/mashup/kkyuni/feature/writing/presentation/upload/WritingUploadFragment.kt
+++ b/feature/writing/presentation/src/main/java/com/mashup/kkyuni/feature/writing/presentation/upload/WritingUploadFragment.kt
@@ -37,7 +37,9 @@ class WritingUploadFragment :
 
         lifecycleScope.launch {
             delay(500L)
-            findNavController().navigate(R.id.previewFragment)
+            WritingUploadFragmentDirections.actionToPreviewFragment().run {
+                findNavController().navigate(this)
+            }
         }
     }
 }

--- a/feature/writing/presentation/src/main/res/layout/fragment_preview.xml
+++ b/feature/writing/presentation/src/main/res/layout/fragment_preview.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<layout xmlns:tools="http://schemas.android.com/tools"
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <data>
 
@@ -13,7 +13,8 @@
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        android:background="#373737">
 
         <ImageView
             android:id="@+id/imageview_back"
@@ -22,8 +23,8 @@
             android:layout_marginVertical="16dp"
             android:layout_marginStart="5dp"
             android:padding="@dimen/toolbar_back_padding"
-            app:layout_constraintBottom_toTopOf="@id/webview_preview"
             android:src="@drawable/ic_back"
+            app:layout_constraintBottom_toTopOf="@id/webview_preview"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
@@ -39,12 +40,13 @@
 
         <com.mashup.kkyuni.widget.KkyuniBottomButton
             android:id="@+id/button_confirm"
+            style="@style/KkyuniBottomButtonStyle"
             android:layout_width="match_parent"
-            android:text="확정하기"
-            android:enabled="true"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="@dimen/common_padding"
             android:layout_marginBottom="24dp"
+            android:enabled="true"
+            android:text="확정하기"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent" />
@@ -67,13 +69,13 @@
 
         <ProgressBar
             android:id="@+id/progress_bar"
+            showUploading="@{viewModel.uploading}"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintBottom_toBottomOf="parent"
-            showUploading="@{viewModel.uploading}" />
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 


### PR DESCRIPTION
일기 확정 시, 서버에서 문자열을 내려주면 Webview.evaluateJavascript() 함수의 콜백이 응답 값을 무조건 json 으로 직렬화를 해버립니다.
역직렬화를 하려 했지만 스스로에게 기각당하고 그냥 replace 로 따옴표를 지워버렸습니다.

그리고 버튼이 자꾸 회색이 되길래 스타일 먹어버렸습니다.