### PR TITLE
확정하기 후 설정 화면 버튼 누르면 종료되던 문제 수정

### DIFF
--- a/feature/writing/presentation/src/main/java/com/mashup/kkyuni/feature/writing/presentation/preview/WritingPreviewFragment.kt
+++ b/feature/writing/presentation/src/main/java/com/mashup/kkyuni/feature/writing/presentation/preview/WritingPreviewFragment.kt
@@ -64,7 +64,7 @@ class WritingPreviewFragment : BindingFragment<FragmentPreviewBinding>(R.layout.
                 repeatOnLifecycle(Lifecycle.State.STARTED) {
                     writingPreviewViewModel.uploading.collect {
                         if (it is UploadState.Complete) {
-                            findNavController().popBackStack(R.id.calendarFragment, true)
+                            findNavController().popBackStack(R.id.calendarFragment, false)
                         }
                     }
                 }


### PR DESCRIPTION
확정하기 누르면 캘린더까지 백스택을 지우는데, inclusive 를 true 로 설정하니 꼬인듯합니다.
false 로 설정하니 잘 됩니다.
정확한 원인은 알기 어려우나 우선은 이렇게 해결합시다.