### PR TITLE
미리보기 화면 툴바 사이즈 조정, 플레이 리스트 월 선택 다이어로그 이상 수정

### DIFF
--- a/feature/playlist/domain/src/main/java/com/mashup/kkyuni/feature/playlist/domain/usecase/GetDateListUseCase.kt
+++ b/feature/playlist/domain/src/main/java/com/mashup/kkyuni/feature/playlist/domain/usecase/GetDateListUseCase.kt
@@ -23,7 +23,7 @@ class GetDateListUseCase @Inject constructor() {
 
         repeat(ITEM_COUNT) {
             if(calendar.get(Calendar.YEAR) <= 2021
-                && calendar.get(Calendar.MONTH) <= 9){
+                && calendar.get(Calendar.MONTH) < 9){
                 // 캘린더영역에 start date가 2021년 9월로 고정되어 있어
                 // 추가 해주지 않는다. 추후 개선시 해당 조건문 제거
                 if(calendar.get(Calendar.YEAR) == 2021

--- a/feature/playlist/domain/src/main/java/com/mashup/kkyuni/feature/playlist/domain/usecase/GetPreviousDateListUseCase.kt
+++ b/feature/playlist/domain/src/main/java/com/mashup/kkyuni/feature/playlist/domain/usecase/GetPreviousDateListUseCase.kt
@@ -21,7 +21,7 @@ class GetPreviousDateListUseCase @Inject constructor() {
         repeat(ITEM_COUNT){
             if(calendar.get(Calendar.YEAR) < 2021
                 || (calendar.get(Calendar.YEAR) == 2021
-                    && calendar.get(Calendar.MONTH) <= 9)
+                    && calendar.get(Calendar.MONTH) < 9)
             ){
                 // 캘린더영역에 start date가 2021년 9월로 고정되어 있어
                 // 추가 해주지 않는다. 추후 개선시 해당 조건문 제거

--- a/feature/writing/presentation/src/main/res/layout/fragment_preview.xml
+++ b/feature/writing/presentation/src/main/res/layout/fragment_preview.xml
@@ -16,15 +16,21 @@
         android:layout_height="match_parent"
         android:background="#373737">
 
+        <View
+            android:id="@+id/view_toolbar"
+            android:layout_width="0dp"
+            android:layout_height="?android:actionBarSize"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"/>
+
         <ImageView
             android:id="@+id/imageview_back"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginVertical="16dp"
             android:layout_marginStart="5dp"
             android:padding="@dimen/toolbar_back_padding"
             android:src="@drawable/ic_back"
-            app:layout_constraintBottom_toTopOf="@id/webview_preview"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 


### PR DESCRIPTION
## Issue
- #69 
## Overview (Required)
- back이미지 클릭 미스를 줄이기 위해 padding값을 일괄적으로 수정했는데 미리보기 화면 툴바 사이즈가 변경되어 수정
- 플레이 리스트 월 선택 다이어로그에서 9월이 표기 안되던 이슈 수정

## Links
-

## Screenshot
Before | After
:--: | :--:
<img src="" width="240" /> | <img src="" width="240" />
